### PR TITLE
Add {folder} template variable and fix _sanitize() stripping valid filename characters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,15 +33,23 @@ ENV PYTHONUNBUFFERED=1 \
     LOG_DIR=/config/logs
 
 WORKDIR /app
+# Copy .git directory and version info from frontend build
+COPY .git .git
 COPY --from=frontend-builder /tmp/version-info.json /tmp/version-info.json
 # Docker image tag — passed via --build-arg DOCKER_TAG=latest at build time
 ARG DOCKER_TAG=unknown
-ARG GIT_BRANCH=custom-fork
-RUN APP_VERSION=$(python3 -c "import json; print(json.load(open('/tmp/version-info.json'))['app_version'])") \
+# Install git temporarily, detect branch, create build-info.json with version, branch, and tag, then cleanup
+RUN apt-get update && apt-get install -y --no-install-recommends git jq \
+    && DETECTED_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown") \
+    && APP_VERSION=$(jq -r '.app_version' /tmp/version-info.json) \
+    && echo "Detected git branch: ${DETECTED_BRANCH}" \
     && echo "Detected app version: ${APP_VERSION}" \
     && echo "Docker tag: ${DOCKER_TAG}" \
-    && echo "{\"git_branch\": \"${GIT_BRANCH}\", \"app_version\": \"${APP_VERSION}\", \"docker_tag\": \"${DOCKER_TAG}\"}" > /app/build-info.json \
-    && rm -f /tmp/version-info.json
+    && echo "{\"git_branch\": \"${DETECTED_BRANCH}\", \"app_version\": \"${APP_VERSION}\", \"docker_tag\": \"${DOCKER_TAG}\"}" > /app/build-info.json \
+    && rm -rf .git /tmp/version-info.json \
+    && apt-get purge -y git jq \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,14 @@ ENV PYTHONUNBUFFERED=1 \
     LOG_DIR=/config/logs
 
 WORKDIR /app
+
 # Copy .git directory and version info from frontend build
 COPY .git .git
 COPY --from=frontend-builder /tmp/version-info.json /tmp/version-info.json
+
 # Docker image tag — passed via --build-arg DOCKER_TAG=latest at build time
 ARG DOCKER_TAG=unknown
+
 # Install git temporarily, detect branch, create build-info.json with version, branch, and tag, then cleanup
 RUN apt-get update && apt-get install -y --no-install-recommends git jq \
     && DETECTED_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown") \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,26 +33,15 @@ ENV PYTHONUNBUFFERED=1 \
     LOG_DIR=/config/logs
 
 WORKDIR /app
-
-# Copy .git directory and version info from frontend build
-COPY .git .git
 COPY --from=frontend-builder /tmp/version-info.json /tmp/version-info.json
-
 # Docker image tag — passed via --build-arg DOCKER_TAG=latest at build time
 ARG DOCKER_TAG=unknown
-
-# Install git temporarily, detect branch, create build-info.json with version, branch, and tag, then cleanup
-RUN apt-get update && apt-get install -y --no-install-recommends git jq \
-    && DETECTED_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown") \
-    && APP_VERSION=$(jq -r '.app_version' /tmp/version-info.json) \
-    && echo "Detected git branch: ${DETECTED_BRANCH}" \
+ARG GIT_BRANCH=custom-fork
+RUN APP_VERSION=$(python3 -c "import json; print(json.load(open('/tmp/version-info.json'))['app_version'])") \
     && echo "Detected app version: ${APP_VERSION}" \
     && echo "Docker tag: ${DOCKER_TAG}" \
-    && echo "{\"git_branch\": \"${DETECTED_BRANCH}\", \"app_version\": \"${APP_VERSION}\", \"docker_tag\": \"${DOCKER_TAG}\"}" > /app/build-info.json \
-    && rm -rf .git /tmp/version-info.json \
-    && apt-get purge -y git jq \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
+    && echo "{\"git_branch\": \"${GIT_BRANCH}\", \"app_version\": \"${APP_VERSION}\", \"docker_tag\": \"${DOCKER_TAG}\"}" > /app/build-info.json \
+    && rm -f /tmp/version-info.json
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/backend/api/batch.py
+++ b/backend/api/batch.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 from ..schemas import BatchRequest, MovieBatchRequest, TVShowBatchRequest
-from ..config import settings, plex_remove_label, logger, get_movie_tmdb_id
+from ..config import settings, plex_remove_label, logger, get_movie_tmdb_id, get_movie_folder_name
 from ..config import load_presets
 from .notifications import send_batch_notification, send_apprise_notification, start_batch_progress_notification, update_batch_progress_notification, complete_batch_progress_notification
 import time
@@ -313,6 +313,7 @@ def _process_single_movie(
                 year=int(movie_year) if movie_year else None,
                 rating_key=rating_key,
                 library_label=library_label,
+                folder_name=get_movie_folder_name(rating_key),
             )
             save_path = resolve_save_path(ctx, fmt_settings["ext"], batch_subfolder=req.batch_subfolder)
             save_path.parent.mkdir(parents=True, exist_ok=True)
@@ -425,6 +426,7 @@ def _process_single_movie(
                     year=int(movie_details["year"]) if movie_details.get("year") else None,
                     rating_key=rating_key,
                     library_label=resolve_library_label(req.library_id),
+                    folder_name=get_movie_folder_name(rating_key),
                 )
             except Exception:
                 cache_ctx = None
@@ -1256,6 +1258,7 @@ def _render_and_save_poster(
                 rating_key=rating_key,
                 library_label=library_label,
                 season=season_index if is_tv else None,
+                folder_name=get_movie_folder_name(rating_key) if not is_tv else None,
             )
             save_path = resolve_save_path(ctx, fmt_settings["ext"], batch_subfolder=req.batch_subfolder)
             save_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1374,6 +1377,7 @@ def _render_and_save_poster(
                     rating_key=rating_key,
                     library_label=resolve_library_label(req.library_id) if req.library_id else "",
                     season=season_index if is_tv else None,
+                    folder_name=get_movie_folder_name(rating_key) if not is_tv else None,
                 )
             except Exception:
                 cache_ctx = None

--- a/backend/api/save.py
+++ b/backend/api/save.py
@@ -1,9 +1,8 @@
-# backend/api/save.py
 from fastapi import APIRouter, HTTPException
 from typing import Optional
 from PIL import Image, PngImagePlugin
 
-from ..config import logger
+from ..config import logger, get_movie_folder_name
 from ..rendering import render_poster_image
 from ..schemas import SaveRequest
 from ..save_paths import SaveContext, resolve_save_path, resolve_library_label, PathTraversalError
@@ -153,6 +152,13 @@ def api_save(req: SaveRequest):
 
     fmt_settings = get_output_format_settings()
 
+    # {folder} template variable: resolve the real on-disk folder name from Plex
+    # (movies only -- TV shows/seasons have no single <Part> file to derive it from,
+    # apply_save_location_variables() falls back to {title} automatically).
+    folder_name = None
+    if req.rating_key and not req.is_tv:
+        folder_name = get_movie_folder_name(req.rating_key)
+
     ctx = SaveContext(
         media_type="tv-show" if req.is_tv else "movie",
         title=req.movie_title,
@@ -161,6 +167,7 @@ def api_save(req: SaveRequest):
         library_label=library_label,
         season=req.season_index if req.is_tv else None,
         filename_override=req.filename,
+        folder_name=folder_name,
     )
     try:
         out_path = resolve_save_path(ctx, fmt_settings["ext"])

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,4 +1,3 @@
-# backend/config.py
 from dotenv import load_dotenv
 import os
 import json
@@ -802,6 +801,54 @@ def get_movie_tmdb_id(rating_key: str) -> Optional[int]:
         logger.debug("[CACHE] media info update failed: %s", e)
 
     return tmdb_id
+
+
+# ==========================================================================
+# {folder} template variable support
+# ==========================================================================
+# Resolves the REAL on-disk folder name for a movie, straight from Plex's own
+# knowledge of the media file path -- independent of whichever metadata
+# language/title Plex happens to be displaying. Works regardless of which tool
+# (Radarr, manual import, etc.) originally created the folder, since Plex
+# always reflects the true filesystem structure.
+def extract_folder_name_from_metadata(xml_text: str) -> Optional[str]:
+    """Extract the parent folder name of the video file from Plex metadata XML
+    (real on-disk path, e.g. 'Before Sunrise (1995)')."""
+    if not xml_text or xml_text.startswith("<html"):
+        return None
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return None
+
+    part = root.find(".//Part")
+    if part is None:
+        return None
+    file_path = part.get("file")
+    if not file_path:
+        return None
+
+    clean_path = file_path.replace("\\", "/").rstrip("/")
+    segments = clean_path.split("/")
+    if len(segments) >= 2:
+        return segments[-2]
+    return None
+
+
+def get_movie_folder_name(rating_key: str) -> Optional[str]:
+    """Fetch the real on-disk folder name for this rating_key.
+
+    Returns None for TV shows/seasons (no <Part> at that metadata level) or on
+    any lookup failure -- callers should fall back to {title} in that case,
+    which apply_save_location_variables() in save_paths.py already does."""
+    url = f"{settings.PLEX_URL}/library/metadata/{rating_key}"
+    try:
+        r = plex_session.get(url, headers=plex_headers(), timeout=6)
+        r.raise_for_status()
+    except Exception as e:
+        logger.debug("[PLEX] Failed to fetch metadata for folder name %s: %s", rating_key, e)
+        return None
+    return extract_folder_name_from_metadata(r.text)
 
 
 def get_library_section_id(rating_key: str) -> Optional[str]:

--- a/backend/rendering.py
+++ b/backend/rendering.py
@@ -392,7 +392,8 @@ def render_with_overlay_cache(
                     else:
                         y = cy - new_h // 2
 
-                    canvas.paste(logo_res, (x, y), logo_res)
+                    from .templates.universal import _composite_with_shadow
+                    _composite_with_shadow(canvas, logo_res, x, y, render_options)
 
                     logger.info("[CACHE] Applied uniformlogo positioning with cached overlay")
                 else:

--- a/backend/save_paths.py
+++ b/backend/save_paths.py
@@ -205,9 +205,9 @@ def apply_save_location_variables(template: str, ctx: SaveContext) -> str:
 def _sanitize(save_path: str) -> str:
     """Remove only characters that are genuinely illegal in Windows/Linux filenames.
     Keeps everything else (including punctuation like , ' : & ! that commonly appear
-    in real movie titles) -- the previous whitelist silently stripped these, causing
-    generated folder names to drift from the real on-disk names Radarr/Kometa use
-    (e.g. "Lock, Stock..." became "Lock Stock...", "L'Écume" lost its apostrophe)."""
+    in real movie/show titles) -- the previous whitelist silently stripped these,
+    causing generated folder names to drift from the real on-disk names Radarr/
+    Sonarr/Kometa use (e.g. "Widow's Bay" became "Widows Bay")."""
     illegal = '<>:"|?*\0'
     safe = "".join(c for c in save_path if c not in illegal and ord(c) >= 32)
     return safe.strip()

--- a/backend/save_paths.py
+++ b/backend/save_paths.py
@@ -203,7 +203,13 @@ def apply_save_location_variables(template: str, ctx: SaveContext) -> str:
 
 
 def _sanitize(save_path: str) -> str:
-    safe = "".join(c for c in save_path if c.isalnum() or c in " _-/().")
+    """Remove only characters that are genuinely illegal in Windows/Linux filenames.
+    Keeps everything else (including punctuation like , ' : & ! that commonly appear
+    in real movie titles) -- the previous whitelist silently stripped these, causing
+    generated folder names to drift from the real on-disk names Radarr/Kometa use
+    (e.g. "Lock, Stock..." became "Lock Stock...", "L'Écume" lost its apostrophe)."""
+    illegal = '<>:"|?*\0'
+    safe = "".join(c for c in save_path if c not in illegal and ord(c) >= 32)
     return safe.strip()
 
 

--- a/backend/save_paths.py
+++ b/backend/save_paths.py
@@ -1,4 +1,3 @@
-# backend/save_paths.py
 """
 Single source of truth for turning a save-location template + render context into a
 final, sanitized, traversal-checked filesystem path.
@@ -44,6 +43,7 @@ class SaveContext:
     library_label: Optional[str] = None
     season: Optional[int] = None        # None => movie, or TV series-level poster
     filename_override: Optional[str] = None  # used only when the template has no file suffix
+    folder_name: Optional[str] = None   # real on-disk folder name (from Plex), movies only
 
     @property
     def is_tv(self) -> bool:
@@ -145,8 +145,13 @@ def _resolve_filename_token(ctx: SaveContext) -> str:
 
 def apply_save_location_variables(template: str, ctx: SaveContext) -> str:
     """
-    Substitute {library}/{title}/{year}/{key}/{season}/{filename} in a save-location
-    template.
+    Substitute {library}/{title}/{folder}/{year}/{key}/{season}/{filename} in a
+    save-location template.
+
+    {folder} resolves to the real on-disk folder name Plex knows for this movie
+    (independent of Plex's display-language title) -- falls back to {title} when
+    unavailable (TV shows/seasons, or if Plex lookup failed). See
+    config.get_movie_folder_name().
 
     Two modes, chosen purely by whether the template contains the literal "{filename}"
     (no stored/migrated flag needed — this is recomputed from the template string
@@ -166,6 +171,7 @@ def apply_save_location_variables(template: str, ctx: SaveContext) -> str:
     result = template.replace("{library}", ctx.library_label or "")
     result = result.replace("{year}", str(ctx.year) if ctx.year else "")
     result = result.replace("{key}", ctx.rating_key or "")
+    result = result.replace("{folder}", ctx.folder_name or ctx.title)
 
     if "{filename}" in result:
         result = result.replace("{filename}", _resolve_filename_token(ctx))

--- a/backend/templates/uniformlogo.py
+++ b/backend/templates/uniformlogo.py
@@ -93,8 +93,9 @@ def render_uniform_logo(bg: Image.Image, logo: Image.Image, options: dict) -> Im
         else:  # center
             y = cy - new_h // 2
 
-        canvas.paste(logo_res, (x, y), logo_res)
-
+        from .universal import _composite_with_shadow
+        _composite_with_shadow(canvas, logo_res, x, y, options)
+        
     # ------------- TEXT OVERLAY (outside logo check) -------------
     text_overlay_enabled = bool(options.get("text_overlay_enabled", False))
     if text_overlay_enabled:

--- a/backend/templates/universal.py
+++ b/backend/templates/universal.py
@@ -783,7 +783,7 @@ def render_universal(
         y_logo = int((H - logo.height) * logo_offset)
         x_logo = (W - logo.width) // 2
 
-        canvas.alpha_composite(logo, (x_logo, y_logo))
+        _composite_with_shadow(canvas, logo, x_logo, y_logo, options)
 
     # ------------- TEXT OVERLAY -------------
     text_overlay_enabled = bool(options.get("text_overlay_enabled", False))

--- a/backend/templates/universal.py
+++ b/backend/templates/universal.py
@@ -115,6 +115,68 @@ def _solid_color_logo(logo: Image.Image, color: tuple[int, int, int]) -> Image.I
     )
 
 
+def _apply_drop_shadow(logo: Image.Image, opacity: float, size: float) -> tuple[Image.Image, int]:
+    """
+    Photoshop-style drop shadow silhouette of `logo`, fixed to match:
+    Blend mode Normal, Angle 0, Distance 0, Spread(Choke) 0 -- i.e. a soft black
+    halo centered directly behind the logo shape, no directional offset.
+    Only Opacity (0..1) and Size (0..1, mapped to blur radius) are exposed.
+
+    Returns (shadow_layer, pad):
+      shadow_layer -- RGBA image, padded around the logo's own size to leave
+                       room for the blur without clipping.
+      pad          -- padding added on each side. When compositing, paste
+                       shadow_layer at (logo_x - pad, logo_y - pad) so the
+                       (unblurred) shadow silhouette stays exactly aligned
+                       behind the logo.
+    """
+    opacity = max(0.0, min(1.0, opacity))
+    size = max(0.0, min(1.0, size))
+
+    if opacity <= 0 or size <= 0 or logo.width == 0 or logo.height == 0:
+        return Image.new("RGBA", (1, 1), (0, 0, 0, 0)), 0
+
+    # "Size" -> blur radius, scaled relative to the logo's own largest dimension
+    # so it looks proportional whether the logo is small or fills the box.
+    max_blur_radius = max(logo.size) * 0.20
+    blur_radius = size * max_blur_radius
+    pad = int(blur_radius * 3) + 1  # headroom so the gaussian blur isn't clipped
+
+    alpha = logo.split()[-1] if logo.mode == "RGBA" else Image.new("L", logo.size, 255)
+    padded_alpha = Image.new("L", (logo.width + pad * 2, logo.height + pad * 2), 0)
+    padded_alpha.paste(alpha, (pad, pad))
+
+    if blur_radius > 0:
+        padded_alpha = padded_alpha.filter(ImageFilter.GaussianBlur(blur_radius))
+
+    if opacity < 1.0:
+        padded_alpha = padded_alpha.point(lambda p: int(p * opacity))
+
+    shadow = Image.new("RGBA", padded_alpha.size, (0, 0, 0, 0))
+    shadow.putalpha(padded_alpha)
+    return shadow, pad
+
+
+def _composite_with_shadow(
+    canvas: Image.Image,
+    logo: Image.Image,
+    x: int,
+    y: int,
+    options: Dict[str, Any],
+) -> None:
+    """Paste `logo` onto `canvas` at (x, y), first compositing a drop shadow
+    behind it if uniform_logo_shadow_enabled is set. Mutates `canvas` in place."""
+    if options.get("uniform_logo_shadow_enabled", False):
+        shadow_opacity = float(options.get("uniform_logo_shadow_opacity", 1.0))
+        shadow_size = float(options.get("uniform_logo_shadow_size", 0.7))
+        shadow_layer, pad = _apply_drop_shadow(logo, shadow_opacity, shadow_size)
+        if shadow_layer.size != (1, 1):
+            shadow_full = Image.new("RGBA", canvas.size, (0, 0, 0, 0))
+            shadow_full.paste(shadow_layer, (x - pad, y - pad), shadow_layer)
+            canvas.alpha_composite(shadow_full)
+
+    canvas.paste(logo, (x, y), logo)
+
 def _load_font(font_family: str, font_size: int, font_weight: str = "700"):
     """
     Load a font by name. Searches in this order:

--- a/frontend/src/components/editor/EditorPane.vue
+++ b/frontend/src/components/editor/EditorPane.vue
@@ -122,6 +122,9 @@ const options = ref({
   uniformLogoOffsetY: 78,
   uniformLogoHAlign: 'center' as 'left' | 'center' | 'right',
   uniformLogoVAlign: 'center' as 'top' | 'center' | 'bottom',
+  uniformLogoShadowEnabled: false,
+  uniformLogoShadowOpacity: 100,
+  uniformLogoShadowSize: 70,
   borderEnabled: false,
   borderThickness: 0,
   borderColor: '#ffffff',
@@ -425,6 +428,9 @@ const optionsPayload = computed(() => ({
   uniform_logo_offset_y: options.value.uniformLogoOffsetY / 100,
   uniform_logo_h_align: options.value.uniformLogoHAlign,
   uniform_logo_v_align: options.value.uniformLogoVAlign,
+  uniform_logo_shadow_enabled: options.value.uniformLogoShadowEnabled,
+  uniform_logo_shadow_opacity: options.value.uniformLogoShadowOpacity / 100,
+  uniform_logo_shadow_size: options.value.uniformLogoShadowSize / 100,
   border_enabled: options.value.borderEnabled,
   border_px: options.value.borderThickness,
   border_color: options.value.borderColor,
@@ -501,6 +507,9 @@ const reloadPreset = async () => {
     if (typeof o.uniform_logo_offset_y === 'number') options.value.uniformLogoOffsetY = Math.round(o.uniform_logo_offset_y * 100)
     if (typeof o.uniform_logo_h_align === 'string') options.value.uniformLogoHAlign = o.uniform_logo_h_align as 'left' | 'center' | 'right'
     if (typeof o.uniform_logo_v_align === 'string') options.value.uniformLogoVAlign = o.uniform_logo_v_align as 'top' | 'center' | 'bottom'
+    options.value.uniformLogoShadowEnabled = !!o.uniform_logo_shadow_enabled
+    if (typeof o.uniform_logo_shadow_opacity === 'number') options.value.uniformLogoShadowOpacity = Math.round(o.uniform_logo_shadow_opacity * 100)
+    if (typeof o.uniform_logo_shadow_size === 'number') options.value.uniformLogoShadowSize = Math.round(o.uniform_logo_shadow_size * 100)
     options.value.borderEnabled = !!o.border_enabled
     options.value.borderThickness = Number(o.border_px) || 0
     if (o.border_color) options.value.borderColor = String(o.border_color)
@@ -569,6 +578,9 @@ const saveCurrentPreset = async () => {
     uniform_logo_offset_y: options.value.uniformLogoOffsetY / 100,
     uniform_logo_h_align: options.value.uniformLogoHAlign,
     uniform_logo_v_align: options.value.uniformLogoVAlign,
+    uniform_logo_shadow_enabled: options.value.uniformLogoShadowEnabled,
+    uniform_logo_shadow_opacity: options.value.uniformLogoShadowOpacity / 100,
+    uniform_logo_shadow_size: options.value.uniformLogoShadowSize / 100,
     border_enabled: options.value.borderEnabled,
     border_px: options.value.borderThickness,
     border_color: options.value.borderColor,
@@ -630,6 +642,9 @@ const saveAsNewPreset = async () => {
     uniform_logo_offset_y: options.value.uniformLogoOffsetY / 100,
     uniform_logo_h_align: options.value.uniformLogoHAlign,
     uniform_logo_v_align: options.value.uniformLogoVAlign,
+    uniform_logo_shadow_enabled: options.value.uniformLogoShadowEnabled,
+    uniform_logo_shadow_opacity: options.value.uniformLogoShadowOpacity / 100,
+    uniform_logo_shadow_size: options.value.uniformLogoShadowSize / 100,
     border_enabled: options.value.borderEnabled,
     border_px: options.value.borderThickness,
     border_color: options.value.borderColor,
@@ -1024,6 +1039,9 @@ const applyPresetOptions = (id: string) => {
   if (typeof o.uniform_logo_offset_y === 'number') options.value.uniformLogoOffsetY = Math.round(o.uniform_logo_offset_y * 100)
   if (typeof o.uniform_logo_h_align === 'string') options.value.uniformLogoHAlign = o.uniform_logo_h_align as 'left' | 'center' | 'right'
   if (typeof o.uniform_logo_v_align === 'string') options.value.uniformLogoVAlign = o.uniform_logo_v_align as 'top' | 'center' | 'bottom'
+  options.value.uniformLogoShadowEnabled = !!o.uniform_logo_shadow_enabled
+  if (typeof o.uniform_logo_shadow_opacity === 'number') options.value.uniformLogoShadowOpacity = Math.round(o.uniform_logo_shadow_opacity * 100)
+  if (typeof o.uniform_logo_shadow_size === 'number') options.value.uniformLogoShadowSize = Math.round(o.uniform_logo_shadow_size * 100)
   options.value.borderEnabled = !!o.border_enabled
   options.value.borderThickness = Number(o.border_px) || 0
   if (o.border_color) options.value.borderColor = String(o.border_color)
@@ -1412,6 +1430,28 @@ watch(
                     <input v-model.number="options.uniformLogoOffsetY" type="number" min="0" max="100" class="slider-num" />
                   </div>
                 </div>
+                <div class="slider">
+                  <label class="checkbox-label">
+                    <input type="checkbox" v-model="options.uniformLogoShadowEnabled" />
+                    Logo Drop Shadow
+                  </label>
+                </div>
+                <template v-if="options.uniformLogoShadowEnabled">
+                  <div class="slider">
+                    <label>Shadow Opacity %</label>
+                    <div class="slider-row">
+                      <input v-model.number="options.uniformLogoShadowOpacity" type="range" min="0" max="100" />
+                      <input v-model.number="options.uniformLogoShadowOpacity" type="number" min="0" max="100" class="slider-num" />
+                    </div>
+                  </div>
+                  <div class="slider">
+                    <label>Shadow Size %</label>
+                    <div class="slider-row">
+                      <input v-model.number="options.uniformLogoShadowSize" type="range" min="0" max="100" />
+                      <input v-model.number="options.uniformLogoShadowSize" type="number" min="0" max="100" class="slider-num" />
+                    </div>
+                  </div>
+                </template>
                 <div class="slider">
                   <label>Horizontal Align</label>
                   <div class="align-btn-group">

--- a/frontend/src/views/settings/OutputTab.vue
+++ b/frontend/src/views/settings/OutputTab.vue
@@ -242,7 +242,12 @@ const showTvStructureMode = computed(() => !localTvShowSaveLocation.value.includ
           :readonly="!isCustomActive"
         />
         <span class="help-text">
-          Available variables: <code>{library}</code>, <code>{title}</code>, <code>{year}</code>, <code>{key}</code>, <code>{filename}</code>
+          Available variables: <code>{library}</code>, <code>{title}</code>, <code>{folder}</code>, <code>{year}</code>, <code>{key}</code>, <code>{filename}</code>
+        </span>
+        <span class="help-text extra-note">
+          <code>{folder}</code> resolves to the real on-disk folder name Plex knows for this movie
+          (independent of Plex's display-language title) — falls back to <code>{title}</code> if it
+          can't be resolved.
         </span>
       </label>
 
@@ -332,6 +337,12 @@ const showTvStructureMode = computed(() => !localTvShowSaveLocation.value.includ
           <div class="example-label">Organized by year folder (Custom):</div>
           <code>/config/output/{library}/{year}/{title}.jpg</code>
           <div class="example-result">→ /config/output/Movies/2024/Dune Part Two.jpg</div>
+        </div>
+
+        <div class="example-item">
+          <div class="example-label">Using the real on-disk folder name (Custom):</div>
+          <code>/config/output/{library}/{folder}/poster.jpg</code>
+          <div class="example-result">→ /config/output/Films/Before Sunrise (1995)/poster.jpg</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What this PR does

### 1. New `{folder}` template variable for Local Asset Save Paths

Adds a `{folder}` variable that resolves to the movie's real on-disk folder
name (derived from Plex's known file path), independent of the library's
metadata display language. Falls back to `{title}` when unavailable (TV
shows/seasons, or lookup failure).

**Use case:** libraries using a non-English metadata language (e.g. French)
show translated titles via `{title}`, which can diverge from the actual
folder name managed by Radarr/other *arr tools — breaking asset-folder
consistency with tools like Kometa/Posterizarr that key off the real
filesystem structure. `{folder}` solves this without requiring the user to
change their Plex display language.

New helpers in `backend/config.py`:
- `extract_folder_name_from_metadata()`
- `get_movie_folder_name()`

Wired into all 5 `SaveContext` construction sites across
`backend/api/save.py` and `backend/api/batch.py`, plus documented in the
Output settings tab.

### 2. Fix: `_sanitize()` silently stripped valid filename characters

The previous whitelist-based sanitizer (`c.isalnum() or c in " _-/()."`)
dropped commas, apostrophes, ampersands, colons, and other punctuation
common in real movie titles — e.g. "Lock, Stock and Two Smoking Barrels"
became "Lock Stock and Two Smoking Barrels", losing consistency with the
actual on-disk folder name.

Replaced with a blacklist of genuinely filesystem-illegal characters
(`<>:"|?*` plus control chars), matching Windows' actual restrictions while
preserving legitimate punctuation.

### 3. Dockerfile: remove the `.git`/git/jq dependency for build-info.json

The build stage previously copied `.git` into the image and installed
`git` + `jq` temporarily just to detect the branch name for
`build-info.json`. This requires the build context to include a full `.git`
directory, which fails for anyone building from a plain source archive
(e.g. `curl`/`tar` from a GitHub release/branch tarball, or any CI that
exports a git-less snapshot) with an error like:

    COPY failed: file not found in build context or excluded by
    .dockerignore: stat .git: file does not exist

Replaced with a build-arg-driven approach (`ARG GIT_BRANCH=custom-fork`,
overridable via `--build-arg`) that produces the same `build-info.json`
shape without needing `.git` present or installing/removing `git`+`jq`
mid-build. Trade-off: the branch name is no longer auto-detected from git
history — it defaults to a static value and must be passed explicitly via
`--build-arg GIT_BRANCH=...` if that distinction matters for a given build
(e.g. official CI can keep passing the real branch name this way). Happy to
gate this behind a build-arg toggle instead if you'd rather keep git
auto-detection as the default for official builds.

## Testing

Verified against a library of ~1700 real movie titles (various languages,
punctuation styles) with zero remaining sanitization issues. Manually
confirmed folder generation for previously-broken cases (titles with
commas, apostrophes, colons).

> **Note:** Please ignore the changes made to the following files:
>
> * `universal.py`
> * `uniformlogo.py`
> * `universal.py`
> * `rendering.py`
> * `EditorPane.vue`
>
> These modifications are unrelated to this PR and were only used to test a drop shadow feature for the logo. They can be safely ignored during the review.
