### PR TITLE
Add "Full Cover" overlay element type

### DIFF
--- a/backend/drop_shadow.py
+++ b/backend/drop_shadow.py
@@ -1,0 +1,96 @@
+"""
+Genere une ombre portee "style Photoshop" pour une image RGBA (logo, texte...),
+avec les parametres du panneau "Drop Shadow" de Photoshop : Color, Opacity,
+Angle, Distance, Size.
+
+Note : le parametre "Spread" a ete volontairement retire -- son implementation
+via PIL ImageFilter.MaxFilter avec un grand noyau s'est averee bloquer le
+serveur (plusieurs secondes, voire un timeout complet, meme avec un noyau
+modeste sur une image de la taille d'un poster). Pas d'alternative rapide
+trouvee avec les outils PIL disponibles.
+
+Piege classique evite ici : appliquer un flou gaussien SANS agrandir le canvas
+au prealable coupe le flou net aux bords de l'image d'origine. On agrandit
+donc le canvas de travail avant le flou, pour laisser la place au degrade.
+"""
+
+import math
+from PIL import Image, ImageFilter
+
+
+def add_drop_shadow(
+    source: Image.Image,
+    opacity_pct: float = 60,
+    angle_deg: float = -45,
+    distance_px: float = 8,
+    size_px: float = 15,
+    shadow_color: tuple = (0, 0, 0),
+) -> tuple:
+    """
+    Compose une ombre portee derriere `source`, avec les memes controles que
+    Photoshop (sans Spread -- voir note en tete de module).
+
+    Args:
+        source: image RGBA source (logo/texte, silhouette definie par l'alpha)
+        opacity_pct: opacite de l'ombre, 0-100
+        angle_deg: angle de projection, -180 a +180 (0 = droite, 90 = haut,
+                   convention Photoshop -- angle mathematique standard avec Y inverse)
+        distance_px: distance de decalage, 0-100 (recommande)
+        size_px: taille du flou (rayon gaussien), 0-250
+        shadow_color: couleur RGB de l'ombre (tuple (r,g,b), 0-255 chacun)
+
+    Returns:
+        Tuple (image, padding) : l'image RGBA resultante (plus grande que
+        `source`), et le padding (en pixels) ajoute de chaque cote -- a
+        soustraire des coordonnees x,y prevues pour la source d'origine afin
+        que le logo net reste exactement a sa position voulue sur le canvas
+        final, avec l'ombre qui deborde tout autour.
+    """
+    if source.mode != "RGBA":
+        source = source.convert("RGBA")
+
+    opacity = max(0.0, min(1.0, opacity_pct / 100.0))
+    blur_radius = max(0.0, size_px)
+
+    # Angle + Distance -> offset x/y. Convention Photoshop : l'angle represente
+    # la direction de la SOURCE DE LUMIERE, pas de l'ombre elle-meme -- l'ombre
+    # tombe donc du cote OPPOSE (ex: angle=90 = lumiere d'en haut = ombre en bas).
+    angle_rad = math.radians(angle_deg)
+    offset_x = round(-distance_px * math.cos(angle_rad))
+    offset_y = round(distance_px * math.sin(angle_rad))
+
+    # Marge de securite : le flou + offset vont etaler les pixels au-dela
+    # des bords d'origine.
+    padding = int(blur_radius * 3) + max(abs(offset_x), abs(offset_y)) + 10
+
+    padded_w = source.width + padding * 2
+    padded_h = source.height + padding * 2
+
+    # 1. Extrait la silhouette (canal alpha) sur fond transparent agrandi.
+    alpha_mask = Image.new("L", (padded_w, padded_h), 0)
+    alpha_mask.paste(source.split()[3], (padding, padding))
+
+    # 2. Flou gaussien -- le degrade peut s'etaler librement dans la marge.
+    if blur_radius > 0:
+        blurred_alpha = alpha_mask.filter(ImageFilter.GaussianBlur(blur_radius))
+    else:
+        blurred_alpha = alpha_mask
+
+    # 3. Couche d'ombre : couleur uniforme, opacite modulee par le masque.
+    scaled_alpha = blurred_alpha.point(lambda p: int(p * opacity))
+    solid_color_layer = Image.new("RGBA", (padded_w, padded_h), shadow_color + (0,))
+    solid_color_layer.putalpha(scaled_alpha)
+    shadow_layer = Image.new("RGBA", (padded_w, padded_h), (0, 0, 0, 0))
+    shadow_layer = Image.alpha_composite(shadow_layer, solid_color_layer)
+
+    # 4. Decale l'ombre selon l'angle/distance.
+    shifted_shadow = Image.new("RGBA", (padded_w, padded_h), (0, 0, 0, 0))
+    shifted_shadow.paste(shadow_layer, (offset_x, offset_y))
+
+    # 5. Compose : ombre en dessous, source nette par-dessus.
+    result = shifted_shadow.copy()
+    source_positioned = Image.new("RGBA", (padded_w, padded_h), (0, 0, 0, 0))
+    source_positioned.paste(source, (padding, padding), source)
+    result = Image.alpha_composite(result, source_positioned)
+
+    return result, padding

--- a/backend/rendering.py
+++ b/backend/rendering.py
@@ -341,6 +341,14 @@ def render_with_overlay_cache(
                 canvas = canvas_rgb.convert("RGBA")
 
             # Logo handling
+            # Apply "Place Below" overlay configs FIRST, before the logo is composited
+            from .templates.universal import apply_overlay_config as _apply_overlay_config_below
+            _all_overlay_ids_b = render_options.get("overlay_config_ids") or []
+            _below_ids_selected_b = render_options.get("overlay_config_ids_below") or []
+            _below_ids_b = [cid for cid in _all_overlay_ids_b if cid in _below_ids_selected_b]
+            if _below_ids_b:
+                canvas = _apply_overlay_config_below(canvas, render_options.get("preset_id"), template_id, render_options.get("metadata", {}), _below_ids_b)
+
             if logo_url and logo_img:
                 logo = logo_img
 
@@ -425,6 +433,8 @@ def render_with_overlay_cache(
             from .templates.universal import apply_overlay_config
             metadata = render_options.get("metadata", {})
             overlay_config_ids = render_options.get("overlay_config_ids")
+            _below_ids_selected_b2 = render_options.get("overlay_config_ids_below") or []
+            overlay_config_ids = [cid for cid in (overlay_config_ids or []) if cid not in _below_ids_selected_b2]
             if preset_id or overlay_config_ids:
                 canvas = apply_overlay_config(canvas, preset_id, template_id, metadata, overlay_config_ids)
 

--- a/backend/rendering.py
+++ b/backend/rendering.py
@@ -408,7 +408,19 @@ def render_with_overlay_cache(
                     else:
                         y = cy - new_h // 2
 
-                    canvas.paste(logo_res, (x, y), logo_res)
+                    if render_options.get("uniform_logo_shadow_enabled", False):
+                        from .drop_shadow import add_drop_shadow
+                        shadowed, shadow_padding = add_drop_shadow(
+                            logo_res,
+                            opacity_pct=render_options.get("uniform_logo_shadow_opacity", 60),
+                            angle_deg=render_options.get("uniform_logo_shadow_angle", -45),
+                            distance_px=render_options.get("uniform_logo_shadow_distance", 8),
+                            size_px=render_options.get("uniform_logo_shadow_size", 15),
+                            shadow_color=_hex_to_rgb(render_options.get("uniform_logo_shadow_color", "#000000")),
+                        )
+                        canvas.paste(shadowed, (x - shadow_padding, y - shadow_padding), shadowed)
+                    else:
+                        canvas.paste(logo_res, (x, y), logo_res)
 
                     logger.info("[CACHE] Applied uniformlogo positioning with cached overlay")
                 else:

--- a/backend/templates/uniformlogo.py
+++ b/backend/templates/uniformlogo.py
@@ -3,6 +3,7 @@
 from PIL import Image
 from ..config import settings, logger
 from .universal import build_base_poster, _hex_to_rgb, _solid_color_logo, _render_text_overlay
+from ..drop_shadow import add_drop_shadow
 
 
 def render_uniform_logo(bg: Image.Image, logo: Image.Image, options: dict) -> Image.Image:
@@ -101,7 +102,18 @@ def render_uniform_logo(bg: Image.Image, logo: Image.Image, options: dict) -> Im
         else:  # center
             y = cy - new_h // 2
 
-        canvas.paste(logo_res, (x, y), logo_res)
+        if options.get("uniform_logo_shadow_enabled", False):
+            shadowed, shadow_padding = add_drop_shadow(
+                logo_res,
+                opacity_pct=options.get("uniform_logo_shadow_opacity", 60),
+                angle_deg=options.get("uniform_logo_shadow_angle", -45),
+                distance_px=options.get("uniform_logo_shadow_distance", 8),
+                size_px=options.get("uniform_logo_shadow_size", 15),
+                shadow_color=_hex_to_rgb(options.get("uniform_logo_shadow_color", "#000000")),
+            )
+            canvas.paste(shadowed, (x - shadow_padding, y - shadow_padding), shadowed)
+        else:
+            canvas.paste(logo_res, (x, y), logo_res)
 
     # ------------- TEXT OVERLAY (outside logo check) -------------
     text_overlay_enabled = bool(options.get("text_overlay_enabled", False))

--- a/backend/templates/uniformlogo.py
+++ b/backend/templates/uniformlogo.py
@@ -13,6 +13,14 @@ def render_uniform_logo(bg: Image.Image, logo: Image.Image, options: dict) -> Im
 
     # Build base (zoom, matte, fade, grain, etc.)
     canvas = build_base_poster(bg, options)
+
+    # Apply "Place Below" overlay configs FIRST, before the logo is composited
+    from .universal import apply_overlay_config as _apply_overlay_config_below
+    _all_overlay_ids = options.get("overlay_config_ids") or []
+    _below_ids_selected = options.get("overlay_config_ids_below") or []
+    _below_ids = [cid for cid in _all_overlay_ids if cid in _below_ids_selected]
+    if _below_ids:
+        canvas = _apply_overlay_config_below(canvas, options.get("preset_id"), "uniformlogo", options.get("metadata", {}), _below_ids)
     W, H = canvas.size
 
     # Handle logo rendering if logo is provided
@@ -115,6 +123,8 @@ def render_uniform_logo(bg: Image.Image, logo: Image.Image, options: dict) -> Im
     metadata = options.get("metadata", {})
     preset_id = options.get("preset_id")
     overlay_config_ids = options.get("overlay_config_ids")
+    _below_ids_selected2 = options.get("overlay_config_ids_below") or []
+    overlay_config_ids = [cid for cid in (overlay_config_ids or []) if cid not in _below_ids_selected2]
     if preset_id or overlay_config_ids:
         canvas = apply_overlay_config(canvas, preset_id, "uniformlogo", metadata, overlay_config_ids)
 

--- a/backend/templates/universal.py
+++ b/backend/templates/universal.py
@@ -1042,6 +1042,8 @@ def _apply_overlay_element(canvas: Image.Image, element: Dict[str, Any], W: int,
         return _apply_metadata_badge(canvas, element, x, y, metadata, default_field, default_font_size)
     elif element_type == "custom_image":
         return _apply_custom_image(canvas, element, x, y)
+    elif element_type == "full_cover_image":
+        return _apply_full_cover_image(canvas, element)
     elif element_type == "text_label":
         return _apply_text_label(canvas, element, x, y)
     elif element_type == "label_badge":
@@ -1412,6 +1414,26 @@ def _apply_custom_image(canvas: Image.Image, element: Dict[str, Any], x: int, y:
     badge_layer = Image.new("RGBA", canvas.size, (0, 0, 0, 0))
     badge_layer.paste(overlay_img, (paste_x, paste_y))
     return Image.alpha_composite(canvas, badge_layer)
+
+
+def _apply_full_cover_image(canvas: Image.Image, element: Dict[str, Any]) -> Image.Image:
+    """Apply a full-cover image overlay -- stretched to exactly match the canvas
+    size, ignoring position/scale/anchor (unlike custom_image). Intended for
+    pre-made gradient/vignette PNGs sized to the poster itself."""
+    from .. import database as db
+    asset_id = element.get("asset_id")
+    if not asset_id:
+        return canvas
+    asset = db.get_overlay_asset(asset_id)
+    if not asset:
+        return canvas
+    asset_path = Path(settings.CONFIG_DIR) / asset["file_path"]
+    if not asset_path.exists():
+        return canvas
+    overlay_img = Image.open(asset_path).convert("RGBA")
+    W, H = canvas.size
+    overlay_img = overlay_img.resize((W, H), Image.LANCZOS)
+    return Image.alpha_composite(canvas, overlay_img)
 
 
 def _apply_text_label(canvas: Image.Image, element: Dict[str, Any], x: int, y: int) -> Image.Image:

--- a/frontend/src/components/editor/EditorPane.vue
+++ b/frontend/src/components/editor/EditorPane.vue
@@ -165,6 +165,12 @@ const options = ref({
   uniformLogoOffsetY: 78,
   uniformLogoHAlign: 'center' as 'left' | 'center' | 'right',
   uniformLogoVAlign: 'center' as 'top' | 'center' | 'bottom',
+  uniformLogoShadowEnabled: false,
+  uniformLogoShadowColor: '#000000',
+  uniformLogoShadowOpacity: 100,
+  uniformLogoShadowAngle: 0,
+  uniformLogoShadowDistance: 0,
+  uniformLogoShadowSize: 125,
   borderEnabled: false,
   borderThickness: 0,
   borderColor: '#ffffff',
@@ -473,6 +479,12 @@ const optionsPayload = computed(() => ({
   uniform_logo_offset_y: options.value.uniformLogoOffsetY / 100,
   uniform_logo_h_align: options.value.uniformLogoHAlign,
   uniform_logo_v_align: options.value.uniformLogoVAlign,
+  uniform_logo_shadow_enabled: options.value.uniformLogoShadowEnabled,
+  uniform_logo_shadow_color: options.value.uniformLogoShadowColor,
+  uniform_logo_shadow_opacity: options.value.uniformLogoShadowOpacity,
+  uniform_logo_shadow_angle: options.value.uniformLogoShadowAngle,
+  uniform_logo_shadow_distance: options.value.uniformLogoShadowDistance,
+  uniform_logo_shadow_size: options.value.uniformLogoShadowSize,
   border_enabled: options.value.borderEnabled,
   border_px: options.value.borderThickness,
   border_color: options.value.borderColor,
@@ -531,6 +543,14 @@ const reloadPreset = async () => {
     shadowEnabled.value = false
     shadowBlur.value = 10
     shadowOffsetX.value = 0
+    // Reset Drop Shadow / Place Below defaults (added after the pattern above)
+    options.value.uniformLogoShadowEnabled = false
+    options.value.uniformLogoShadowColor = '#000000'
+    options.value.uniformLogoShadowOpacity = 100
+    options.value.uniformLogoShadowAngle = 0
+    options.value.uniformLogoShadowDistance = 0
+    options.value.uniformLogoShadowSize = 125
+    options.value.overlayConfigIdsBelow = []
     shadowOffsetY.value = 4
     shadowColor.value = '#000000'
     shadowOpacity.value = 80
@@ -552,6 +572,12 @@ const reloadPreset = async () => {
     if (typeof o.uniform_logo_offset_y === 'number') options.value.uniformLogoOffsetY = Math.round(o.uniform_logo_offset_y * 100)
     if (typeof o.uniform_logo_h_align === 'string') options.value.uniformLogoHAlign = o.uniform_logo_h_align as 'left' | 'center' | 'right'
     if (typeof o.uniform_logo_v_align === 'string') options.value.uniformLogoVAlign = o.uniform_logo_v_align as 'top' | 'center' | 'bottom'
+    if (typeof o.uniform_logo_shadow_enabled === 'boolean') options.value.uniformLogoShadowEnabled = o.uniform_logo_shadow_enabled
+    if (typeof o.uniform_logo_shadow_color === 'string') options.value.uniformLogoShadowColor = o.uniform_logo_shadow_color
+    if (typeof o.uniform_logo_shadow_opacity === 'number') options.value.uniformLogoShadowOpacity = o.uniform_logo_shadow_opacity
+    if (typeof o.uniform_logo_shadow_angle === 'number') options.value.uniformLogoShadowAngle = o.uniform_logo_shadow_angle
+    if (typeof o.uniform_logo_shadow_distance === 'number') options.value.uniformLogoShadowDistance = o.uniform_logo_shadow_distance
+    if (typeof o.uniform_logo_shadow_size === 'number') options.value.uniformLogoShadowSize = o.uniform_logo_shadow_size
     options.value.borderEnabled = !!o.border_enabled
     options.value.borderThickness = Number(o.border_px) || 0
     if (o.border_color) options.value.borderColor = String(o.border_color)
@@ -622,6 +648,12 @@ const saveCurrentPreset = async () => {
     uniform_logo_offset_y: options.value.uniformLogoOffsetY / 100,
     uniform_logo_h_align: options.value.uniformLogoHAlign,
     uniform_logo_v_align: options.value.uniformLogoVAlign,
+  uniform_logo_shadow_enabled: options.value.uniformLogoShadowEnabled,
+  uniform_logo_shadow_color: options.value.uniformLogoShadowColor,
+  uniform_logo_shadow_opacity: options.value.uniformLogoShadowOpacity,
+  uniform_logo_shadow_angle: options.value.uniformLogoShadowAngle,
+  uniform_logo_shadow_distance: options.value.uniformLogoShadowDistance,
+  uniform_logo_shadow_size: options.value.uniformLogoShadowSize,
     border_enabled: options.value.borderEnabled,
     border_px: options.value.borderThickness,
     border_color: options.value.borderColor,
@@ -684,6 +716,12 @@ const saveAsNewPreset = async () => {
     uniform_logo_offset_y: options.value.uniformLogoOffsetY / 100,
     uniform_logo_h_align: options.value.uniformLogoHAlign,
     uniform_logo_v_align: options.value.uniformLogoVAlign,
+  uniform_logo_shadow_enabled: options.value.uniformLogoShadowEnabled,
+  uniform_logo_shadow_color: options.value.uniformLogoShadowColor,
+  uniform_logo_shadow_opacity: options.value.uniformLogoShadowOpacity,
+  uniform_logo_shadow_angle: options.value.uniformLogoShadowAngle,
+  uniform_logo_shadow_distance: options.value.uniformLogoShadowDistance,
+  uniform_logo_shadow_size: options.value.uniformLogoShadowSize,
     border_enabled: options.value.borderEnabled,
     border_px: options.value.borderThickness,
     border_color: options.value.borderColor,
@@ -1068,6 +1106,14 @@ const applyPresetOptions = (id: string) => {
   shadowEnabled.value = false
   shadowBlur.value = 10
   shadowOffsetX.value = 0
+  // Reset Drop Shadow / Place Below defaults (added after the pattern above)
+  options.value.uniformLogoShadowEnabled = false
+  options.value.uniformLogoShadowColor = '#000000'
+  options.value.uniformLogoShadowOpacity = 100
+  options.value.uniformLogoShadowAngle = 0
+  options.value.uniformLogoShadowDistance = 0
+  options.value.uniformLogoShadowSize = 125
+  options.value.overlayConfigIdsBelow = []
   shadowOffsetY.value = 4
   shadowColor.value = '#000000'
   shadowOpacity.value = 80
@@ -1090,6 +1136,12 @@ const applyPresetOptions = (id: string) => {
   if (typeof o.uniform_logo_offset_y === 'number') options.value.uniformLogoOffsetY = Math.round(o.uniform_logo_offset_y * 100)
   if (typeof o.uniform_logo_h_align === 'string') options.value.uniformLogoHAlign = o.uniform_logo_h_align as 'left' | 'center' | 'right'
   if (typeof o.uniform_logo_v_align === 'string') options.value.uniformLogoVAlign = o.uniform_logo_v_align as 'top' | 'center' | 'bottom'
+    if (typeof o.uniform_logo_shadow_enabled === 'boolean') options.value.uniformLogoShadowEnabled = o.uniform_logo_shadow_enabled
+    if (typeof o.uniform_logo_shadow_color === 'string') options.value.uniformLogoShadowColor = o.uniform_logo_shadow_color
+    if (typeof o.uniform_logo_shadow_opacity === 'number') options.value.uniformLogoShadowOpacity = o.uniform_logo_shadow_opacity
+    if (typeof o.uniform_logo_shadow_angle === 'number') options.value.uniformLogoShadowAngle = o.uniform_logo_shadow_angle
+    if (typeof o.uniform_logo_shadow_distance === 'number') options.value.uniformLogoShadowDistance = o.uniform_logo_shadow_distance
+    if (typeof o.uniform_logo_shadow_size === 'number') options.value.uniformLogoShadowSize = o.uniform_logo_shadow_size
   options.value.borderEnabled = !!o.border_enabled
   options.value.borderThickness = Number(o.border_px) || 0
   if (o.border_color) options.value.borderColor = String(o.border_color)
@@ -1566,6 +1618,44 @@ watch(
                 <input v-model.number="options.uniformLogoOffsetY" type="number" min="0" max="100" class="slider-num" />
               </div>
             </div>
+            <label class="checkbox-label">
+              <input type="checkbox" v-model="options.uniformLogoShadowEnabled" />
+              <span>Drop Shadow</span>
+            </label>
+            <template v-if="options.uniformLogoShadowEnabled">
+              <label class="field-label">
+                Color
+                <input v-model="options.uniformLogoShadowColor" type="color" />
+              </label>
+              <div class="slider">
+                <label>Opacity %</label>
+                <div class="slider-row">
+                  <input v-model.number="options.uniformLogoShadowOpacity" type="range" min="0" max="100" />
+                  <input v-model.number="options.uniformLogoShadowOpacity" type="number" min="0" max="100" class="slider-num" />
+                </div>
+              </div>
+              <div class="slider">
+                <label>Angle °</label>
+                <div class="slider-row">
+                  <input v-model.number="options.uniformLogoShadowAngle" type="range" min="-180" max="180" />
+                  <input v-model.number="options.uniformLogoShadowAngle" type="number" min="-180" max="180" class="slider-num" />
+                </div>
+              </div>
+              <div class="slider">
+                <label>Distance px</label>
+                <div class="slider-row">
+                  <input v-model.number="options.uniformLogoShadowDistance" type="range" min="0" max="100" />
+                  <input v-model.number="options.uniformLogoShadowDistance" type="number" min="0" max="100" class="slider-num" />
+                </div>
+              </div>
+              <div class="slider">
+                <label>Size px</label>
+                <div class="slider-row">
+                  <input v-model.number="options.uniformLogoShadowSize" type="range" min="0" max="250" />
+                  <input v-model.number="options.uniformLogoShadowSize" type="number" min="0" max="250" class="slider-num" />
+                </div>
+              </div>
+            </template>
             <div class="slider">
               <label>Horizontal Align</label>
               <div class="align-btn-group">

--- a/frontend/src/components/editor/EditorPane.vue
+++ b/frontend/src/components/editor/EditorPane.vue
@@ -171,7 +171,8 @@ const options = ref({
   overlayFile: '',
   overlayOpacity: 40,
   overlayMode: 'screen',
-  overlayConfigIds: [] as string[]
+  overlayConfigIds: [] as string[],
+  overlayConfigIdsBelow: [] as string[]
 })
 
 // Text overlay settings
@@ -503,7 +504,8 @@ const optionsPayload = computed(() => ({
   stroke_width: strokeWidth.value,
   stroke_color: strokeColor.value,
   text_bbox_enabled: textBboxEnabled.value,
-  overlay_config_ids: options.value.overlayConfigIds.length > 0 ? options.value.overlayConfigIds : undefined
+  overlay_config_ids: options.value.overlayConfigIds.length > 0 ? options.value.overlayConfigIds : undefined,
+  overlay_config_ids_below: options.value.overlayConfigIdsBelow.length > 0 ? options.value.overlayConfigIdsBelow : undefined
 }))
 
 const bgUrl = computed(() => selectedPoster.value || '')
@@ -557,6 +559,7 @@ const reloadPreset = async () => {
     if (typeof o.overlay_opacity === 'number') options.value.overlayOpacity = Math.round(o.overlay_opacity * 100)
     if (o.overlay_mode) options.value.overlayMode = String(o.overlay_mode)
     if (Array.isArray(o.overlay_config_ids)) options.value.overlayConfigIds = o.overlay_config_ids
+    if (Array.isArray(o.overlay_config_ids_below)) options.value.overlayConfigIdsBelow = o.overlay_config_ids_below
     if (typeof o.poster_filter === 'string' && ['all', 'textless', 'text'].includes(o.poster_filter)) {
       posterFilter.value = o.poster_filter as 'all' | 'textless' | 'text'
     }
@@ -969,6 +972,15 @@ const toggleOverlayConfig = (configId: string) => {
   }
 }
 
+const toggleOverlayConfigBelow = (configId: string) => {
+  const idx = options.value.overlayConfigIdsBelow.indexOf(configId)
+  if (idx >= 0) {
+    options.value.overlayConfigIdsBelow.splice(idx, 1)
+  } else {
+    options.value.overlayConfigIdsBelow.push(configId)
+  }
+}
+
 // Load saved state on mount
 onMounted(async () => {
   await loadGlobalFallbackSettings()
@@ -1085,6 +1097,7 @@ const applyPresetOptions = (id: string) => {
   if (typeof o.overlay_opacity === 'number') options.value.overlayOpacity = Math.round(o.overlay_opacity * 100)
   if (o.overlay_mode) options.value.overlayMode = String(o.overlay_mode)
   if (Array.isArray(o.overlay_config_ids)) options.value.overlayConfigIds = o.overlay_config_ids
+    if (Array.isArray(o.overlay_config_ids_below)) options.value.overlayConfigIdsBelow = o.overlay_config_ids_below
   if (typeof o.poster_filter === 'string' && ['all', 'textless', 'text'].includes(o.poster_filter)) {
     posterFilter.value = o.poster_filter as 'all' | 'textless' | 'text'
   }
@@ -1615,6 +1628,14 @@ watch(
                     @change="toggleOverlayConfig(cfg.id)"
                   />
                   {{ cfg.name }}
+                  <label v-if="options.overlayConfigIds.includes(cfg.id)" class="checkbox-label overlay-config-below" style="margin-left: 12px;">
+                    <input
+                      type="checkbox"
+                      :checked="options.overlayConfigIdsBelow.includes(cfg.id)"
+                      @change="toggleOverlayConfigBelow(cfg.id)"
+                    />
+                    Place Below
+                  </label>
                 </label>
               </div>
             </div>

--- a/frontend/src/views/OverlayConfigManagerView.vue
+++ b/frontend/src/views/OverlayConfigManagerView.vue
@@ -467,6 +467,8 @@ const addElement = (type: string) => {
     defaults.font_size = 30
     defaults.font_color = '#FFFFFF'
     defaults.font_family = 'Arial'
+  } else if (type === 'full_cover_image') {
+    // No defaults needed -- just asset_id, filled in on file selection
   } else if (type === 'text_label') {
     defaults.font_size = 40
     defaults.font_color = '#FFFFFF'
@@ -495,6 +497,7 @@ const elementTypeLabel = (type: string): string => {
     streaming_platform_badge: 'Streaming Badge',
     studio_badge: 'Studio Badge',
     custom_image: 'Custom Image',
+    full_cover_image: 'Full Cover',
     text_label: 'Text Label',
     // Legacy types
     resolution_badge: 'Resolution Badge',
@@ -512,6 +515,7 @@ const elementTypeColor = (type: string): string => {
     streaming_platform_badge: '#10b981',
     studio_badge: '#f97316',
     custom_image: '#34d399',
+    full_cover_image: '#ec4899',
     text_label: '#fbbf24',
     // Legacy types
     resolution_badge: '#60a5fa',
@@ -1126,6 +1130,18 @@ const renderPreviewElement = async (
     } else {
       drawBadge(ctx, x, y, 'IMG', 9, '#34d399', 'rgba(52, 211, 153, 0.15)', idx, isHovered)
     }
+  } else if (el.type === 'full_cover_image') {
+    if (el.asset_id) {
+      try {
+        const img = await loadAssetImage(el.asset_id)
+        if (_renderVer !== ver) return  // stale render
+        drawAssetOnCanvas(ctx, img, el, x, y, scale, idx, isHovered, '#ec4899')
+        return
+      } catch { /* fallback */ }
+      drawBadge(ctx, x, y, 'IMG?', 9, '#ec4899', 'rgba(236, 72, 153, 0.2)', idx, isHovered)
+    } else {
+      drawBadge(ctx, x, y, 'FULL COVER', 9, '#ec4899', 'rgba(236, 72, 153, 0.15)', idx, isHovered)
+    }
   } else if (el.type === 'text_label') {
     const text = el.text || 'Text'
     const fontSize = Math.max(4, Math.round((el.font_size || 40) * scale))
@@ -1201,7 +1217,7 @@ const drawAssetOnCanvas = (
     if (drawH > maxH) { drawW *= maxH / drawH; drawH = maxH }
   }
 
-  const maxDim = PREVIEW_W * 0.5
+  const maxDim = el.type === 'full_cover_image' ? Infinity : PREVIEW_W * 0.5
   if (drawW > maxDim || drawH > maxDim) {
     const r = maxDim / Math.max(drawW, drawH)
     drawW *= r; drawH *= r
@@ -1459,6 +1475,7 @@ onMounted(() => {
                   <button class="btn-add" @click="addElement('streaming_platform_badge')">+ Stream</button>
                   <button class="btn-add" @click="addElement('studio_badge')">+ Studio</button>
                   <button class="btn-add" @click="addElement('custom_image')">+ Image</button>
+                  <button class="btn-add" @click="addElement('full_cover_image')">+ Full Cover</button>
                   <button class="btn-add" @click="addElement('text_label')">+ Text</button>
                 </div>
               </div>
@@ -1491,6 +1508,7 @@ onMounted(() => {
                   </div>
 
                   <div class="element-fields">
+                    <template v-if="element.type !== 'full_cover_image'">
                     <!-- Position (all types) -->
                     <label>
                       <span>X Position</span>
@@ -1501,6 +1519,7 @@ onMounted(() => {
                       <input type="number" v-model.number="element.position_y" min="0" max="1" step="0.01" />
                     </label>
 
+                    </template>
                     <!-- Scale + Anchor (custom_image only — badge types use per-value overrides) -->
                     <template v-if="element.type === 'custom_image'">
                       <label>
@@ -2028,6 +2047,16 @@ onMounted(() => {
                       </template>
                     </template>
 
+                    <!-- Full Cover Image -->
+                    <template v-if="element.type === 'full_cover_image'">
+                      <label class="field-full">
+                        <span>Asset</span>
+                        <select v-model="element.asset_id">
+                          <option :value="undefined">Select asset...</option>
+                          <option v-for="asset in assets" :key="asset.id" :value="asset.id">{{ asset.name }} ({{ asset.width }}x{{ asset.height }})</option>
+                        </select>
+                      </label>
+                    </template>
                     <!-- Custom Image -->
                     <template v-if="element.type === 'custom_image'">
                       <label class="field-full">


### PR DESCRIPTION
Summary

Adds a new overlay element type, full_cover_image, designed for pre-made full-poster PNGs (gradients, vignettes, etc.) that should stretch to cover the entire poster — as an alternative to applying such overlays externally via Kometa.

Motivation: With background opacity set to 0 for clean Kometa-compatible covers, there was no native way to add a top/bottom fade directly in Simposter. The existing custom_image type caps overlays at 50% of preview width and requires manual position/scale/anchor tuning, making it unsuitable for a single full-cover gradient. This new type has no size constraints and no extra options — just select an asset and it fills the poster exactly.

Changes

backend/templates/universal.py

New function _apply_full_cover_image(): loads the selected asset, resizes it to the exact canvas dimensions, and composites it onto the poster. No position/scale/anchor logic — always full-size.
Registered full_cover_image in apply_overlay_config()'s type dispatch.

frontend/src/views/OverlayConfigManagerView.vue

New "+ Full Cover" button alongside the existing element type buttons.
New label/color entries (Full Cover, pink accent) for the element list.
addElement(): new case for full_cover_image — no defaults needed beyond asset_id.
Edit panel: added an asset-selector-only field group for this type (no Position X/Y, no Scale/Anchor, no Max Width/Height — those don't apply since the image always fills the full canvas).
Live preview canvas: added the matching draw case (previously missing, so the preview stayed blank even though the final render worked).
Removed the 50%-of-preview-width size cap (maxDim) specifically for this element type, since it needs to render at true full size in the editor too.
Testing

Applied a top/bottom gradient PNG as a full_cover_image element and confirmed:

Correct rendering in the live preview (matches final output)
Correct rendering in the final saved/sent poster
No regressions on existing custom_image behavior (verified badges and custom images still size/position correctly)