### PR TITLE
Fix TV show "(Series)" filename suffix + add {folder} support for TV shows

### DIFF
--- a/backend/api/plexsend.py
+++ b/backend/api/plexsend.py
@@ -8,7 +8,7 @@ from PIL import Image
 from pydantic import BaseModel
 from typing import List, Optional
 
-from ..config import settings, plex_headers, plex_session, plex_remove_label, logger, get_movie_folder_name
+from ..config import settings, plex_headers, plex_session, plex_remove_label, logger, get_movie_folder_name, get_media_folder_name
 from ..rendering import render_poster_image
 from ..schemas import PlexSendRequest, PlexLogoSendRequest
 from ..save_paths import SaveContext, resolve_library_label, save_or_cache_render, load_cached_render, save_to_asset_folder_on_send_enabled
@@ -158,8 +158,8 @@ def api_plex_send(req: PlexSendRequest):
         # worth the extra Plex metadata fetch when that setting is actually on — it's off
         # by default, and save_or_cache_render() ignores folder_name entirely otherwise.
         folder_name = None
-        if not is_tv and save_to_asset_folder_on_send_enabled():
-            folder_name = get_movie_folder_name(req.rating_key)
+        if save_to_asset_folder_on_send_enabled():
+            folder_name = get_media_folder_name(req.rating_key, is_tv)
         cache_ctx = SaveContext(
             media_type="tv-show" if is_tv else "movie",
             title=movie_details.get("title") or "",
@@ -336,12 +336,13 @@ def api_render_cache_cached_keys():
                 year=m.get("year"),
                 rating_key=m.get("rating_key"),
                 library_label=resolve_library_label(m.get("library_id")),
-                folder_name=get_movie_folder_name(m.get("rating_key")) if movie_template_uses_folder else None,
+                folder_name=get_media_folder_name(m.get("rating_key"), False) if movie_template_uses_folder else None,
             )
             if resolve_save_path(ctx, ".jpg").exists():
                 keys.append(m["rating_key"])
         except Exception:
             continue
+    tv_template_uses_folder = "{folder}" in get_save_template("tv-show")
     for s in db.get_cached_tv_shows():
         try:
             ctx = SaveContext(
@@ -350,6 +351,7 @@ def api_render_cache_cached_keys():
                 year=s.get("year"),
                 rating_key=s.get("rating_key"),
                 library_label=resolve_library_label(s.get("library_id")),
+                folder_name=get_media_folder_name(s.get("rating_key"), True) if tv_template_uses_folder else None,
             )
             if resolve_save_path(ctx, ".jpg").exists():
                 keys.append(s["rating_key"])
@@ -379,8 +381,8 @@ def api_render_cache_preview(
     title, year = db.get_title_for_rating_key(rating_key)
     try:
         folder_name = None
-        if not is_tv and save_to_asset_folder_on_send_enabled():
-            folder_name = get_movie_folder_name(rating_key)
+        if save_to_asset_folder_on_send_enabled():
+            folder_name = get_media_folder_name(rating_key, is_tv)
         ctx = SaveContext(
             media_type="tv-show" if is_tv else "movie",
             title=title or "",
@@ -453,8 +455,8 @@ def api_render_cache_resend(rating_key: str, req: ResendCachedRequest):
     _title_for_ctx, _year_for_ctx = db.get_title_for_rating_key(rating_key)
     try:
         _folder_name_for_ctx = None
-        if not req.is_tv and save_to_asset_folder_on_send_enabled():
-            _folder_name_for_ctx = get_movie_folder_name(rating_key)
+        if save_to_asset_folder_on_send_enabled():
+            _folder_name_for_ctx = get_media_folder_name(rating_key, req.is_tv)
         top_ctx = SaveContext(
             media_type="tv-show" if req.is_tv else "movie",
             title=_title_for_ctx or "",

--- a/backend/api/save.py
+++ b/backend/api/save.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 from io import BytesIO
 from PIL import Image, PngImagePlugin
 
-from ..config import logger, get_movie_folder_name
+from ..config import logger, get_movie_folder_name, get_media_folder_name
 from ..rendering import render_poster_image
 from ..schemas import SaveRequest
 from ..save_paths import SaveContext, resolve_save_path, resolve_library_label, PathTraversalError
@@ -227,8 +227,8 @@ def api_save(req: SaveRequest):
     # (movies only -- TV shows/seasons have no single <Part> file to derive it from,
     # apply_save_location_variables() falls back to {title} automatically).
     folder_name = None
-    if req.rating_key and not req.is_tv:
-        folder_name = get_movie_folder_name(req.rating_key)
+    if req.rating_key:
+        folder_name = get_media_folder_name(req.rating_key, req.is_tv)
 
     ctx = SaveContext(
         media_type="tv-show" if req.is_tv else "movie",

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,6 +1,7 @@
 from dotenv import load_dotenv
 import os
 import json
+import re
 import logging
 from logging.handlers import TimedRotatingFileHandler
 import shutil
@@ -859,10 +860,9 @@ def get_movie_folder_name(rating_key: str) -> Optional[str]:
 
 def extract_show_folder_name_from_episode_metadata(xml_text: str) -> Optional[str]:
     """Extract the show-level parent folder name from an EPISODE's Plex metadata
-    XML (real on-disk path, e.g. '/tv/Lanterns/Season 01/Lanterns - S01E01.mkv'
-    -> 'Lanterns'). Same principle as extract_folder_name_from_metadata() for
-    movies, but goes up THREE directory levels instead of two, since a show's
-    structure is Show/Season NN/episode.ext rather than Movie (Year)/file.ext."""
+    XML. Handles TWO structures: Show/Season NN/episode.ext (most shows, goes
+    up 3 levels), or Show/episode.ext (no season subfolder, goes up 2 levels)
+    -- detected by checking if the immediate parent looks like a season folder."""
     if not xml_text or xml_text.startswith("<html"):
         return None
     try:
@@ -878,10 +878,20 @@ def extract_show_folder_name_from_episode_metadata(xml_text: str) -> Optional[st
         return None
 
     clean_path = file_path.replace("\\", "/").rstrip("/")
-    segments = clean_path.split("/")
-    if len(segments) >= 5:
+    segments = [s for s in clean_path.split("/") if s]
+
+    if len(segments) < 2:
+        return None
+
+    parent = segments[-2]
+    is_season_folder = bool(re.match(r'^(season\s*\d+|specials?)$', parent, re.IGNORECASE))
+
+    if is_season_folder:
+        if len(segments) < 3:
+            return None
         return segments[-3]
-    return None
+    else:
+        return parent
 
 
 def get_show_folder_name(rating_key: str) -> Optional[str]:

--- a/backend/config.py
+++ b/backend/config.py
@@ -857,6 +857,86 @@ def get_movie_folder_name(rating_key: str) -> Optional[str]:
     return extract_folder_name_from_metadata(r.text)
 
 
+def extract_show_folder_name_from_episode_metadata(xml_text: str) -> Optional[str]:
+    """Extract the show-level parent folder name from an EPISODE's Plex metadata
+    XML (real on-disk path, e.g. '/tv/Lanterns/Season 01/Lanterns - S01E01.mkv'
+    -> 'Lanterns'). Same principle as extract_folder_name_from_metadata() for
+    movies, but goes up THREE directory levels instead of two, since a show's
+    structure is Show/Season NN/episode.ext rather than Movie (Year)/file.ext."""
+    if not xml_text or xml_text.startswith("<html"):
+        return None
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return None
+
+    part = root.find(".//Part")
+    if part is None:
+        return None
+    file_path = part.get("file")
+    if not file_path:
+        return None
+
+    clean_path = file_path.replace("\\", "/").rstrip("/")
+    segments = clean_path.split("/")
+    if len(segments) >= 5:
+        return segments[-3]
+    return None
+
+
+def get_show_folder_name(rating_key: str) -> Optional[str]:
+    """Fetch the real on-disk folder name for a TV show's rating_key.
+
+    Unlike movies, a show's own metadata has no <Part> element (only episodes
+    do), so this first fetches the show's episode list and uses the first
+    episode found to derive the parent show folder.
+
+    Returns None if the show has no episodes yet, or on any lookup failure --
+    callers should fall back to {title} in that case, same as movies."""
+    episodes_url = f"{settings.PLEX_URL}/library/metadata/{rating_key}/allLeaves"
+    try:
+        r = plex_session.get(episodes_url, headers=plex_headers(), timeout=6)
+        r.raise_for_status()
+    except Exception as e:
+        logger.debug("[PLEX] Failed to fetch episode list for show folder name %s: %s", rating_key, e)
+        return None
+
+    try:
+        root = ET.fromstring(r.text)
+    except ET.ParseError:
+        return None
+
+    first_episode = root.find(".//Video")
+    if first_episode is None:
+        return None
+    episode_rating_key = first_episode.get("ratingKey")
+    if not episode_rating_key:
+        return None
+
+    episode_url = f"{settings.PLEX_URL}/library/metadata/{episode_rating_key}"
+    try:
+        r2 = plex_session.get(episode_url, headers=plex_headers(), timeout=6)
+        r2.raise_for_status()
+    except Exception as e:
+        logger.debug("[PLEX] Failed to fetch episode metadata for show folder name %s: %s", rating_key, e)
+        return None
+
+    return extract_show_folder_name_from_episode_metadata(r2.text)
+
+
+def get_media_folder_name(rating_key: str, is_tv: bool = False) -> Optional[str]:
+    """Single entry point for {folder} resolution -- routes to get_show_folder_name()
+    for TV shows or get_movie_folder_name() for movies. Callers should use this
+    instead of calling get_movie_folder_name() directly, so TV shows also get
+    a resolved {folder} instead of always falling back to {title}.
+
+    Behavior for movies is byte-identical to calling get_movie_folder_name()
+    directly (this just forwards to it) -- no change to existing behavior."""
+    if is_tv:
+        return get_show_folder_name(rating_key)
+    return get_movie_folder_name(rating_key)
+
+
 def get_library_section_id(rating_key: str) -> Optional[str]:
     """
     Fetch metadata for a rating_key and return the librarySectionID if present.

--- a/frontend/src/components/editor/TvShowEditorPane.vue
+++ b/frontend/src/components/editor/TvShowEditorPane.vue
@@ -1,4 +1,4 @@
-﻿<script setup lang="ts">
+<script setup lang="ts">
 import { computed, onMounted, ref, watch, nextTick } from 'vue'
 import { useRoute } from 'vue-router'
 import type { MovieInput } from '../../services/types'
@@ -1886,7 +1886,7 @@ const doSave = async () => {
     }
 
     // Create a temporary movie object for this season with proper media type
-    const seasonMovie = { ...props.movie, key: seasonKey, title: season.title, mediaType: 'tv-show' as const }
+    const seasonMovie = { ...props.movie, key: seasonKey, title: season.isSeries ? props.movie.title : season.title, mediaType: 'tv-show' as const }
 
     // Pass season index (null for series poster)
     const seasonIndex = season.isSeries ? null : season.index

--- a/frontend/src/views/settings/OutputTab.vue
+++ b/frontend/src/views/settings/OutputTab.vue
@@ -248,7 +248,7 @@ const showTvStructureMode = computed(() => !localTvShowSaveLocation.value.includ
           Available variables: <code>{library}</code>, <code>{title}</code>, <code>{folder}</code>, <code>{year}</code>, <code>{key}</code>, <code>{filename}</code>
         </span>
         <span class="help-text extra-note">
-          <code>{folder}</code> resolves to the real on-disk folder name Plex knows for this movie
+          <code>{folder}</code> resolves to the real on-disk folder name Plex knows for this movie or TV show (show-level only, not individual seasons)
           (independent of Plex's display-language title) — falls back to <code>{title}</code> if it
           can't be resolved.
         </span>
@@ -263,7 +263,7 @@ const showTvStructureMode = computed(() => !localTvShowSaveLocation.value.includ
           :readonly="!isCustomActive"
         />
         <span class="help-text">
-          Available variables: <code>{library}</code>, <code>{title}</code>, <code>{year}</code>, <code>{season}</code>, <code>{filename}</code>
+          Available variables: <code>{library}</code>, <code>{title}</code>, <code>{folder}</code>, <code>{year}</code>, <code>{season}</code>, <code>{filename}</code>
         </span>
         <span class="help-text extra-note">
           <code>{filename}</code> resolves to <code>poster</code> (movie or show poster) or <code>SeasonNN</code> (a season


### PR DESCRIPTION
More work for you 😄 Two fixes this time, both around TV shows.

### Fix 1: "(Series)" leaking into the actual saved filename

When saving/sending a TV show's series-level poster, the filename ended up as "ShowName (Series)" instead of just "ShowName" when using the variable {title} and the button "Save to Disk". Turned out `TvShowEditorPane.vue` builds an internal `Season` entry for the series-level tab with `title: \`${props.movie.title} (Series)\`` (used for the tab label), but `doSave()` was reusing that same `season.title` — suffix included — as the real title passed to the backend for the series entry.

**Fix in `TvShowEditorPane.vue`:** use the real `props.movie.title` specifically for the series-level save, keep `season.title` as-is for actual season saves (where it's fine/expected).

### Fix 2: `{folder}` now works for TV shows too

Context: Kometa matches asset folders by the real on-disk folder name, same as it does for movies — so without this, any show whose Sonarr/on-disk folder name differs from what Plex displays (localized titles, missing/extra year, etc.) would never get its cover picked up correctly by Kometa.

Previously `{folder}` only resolved for movies — the code had a clear comment explaining why (`get_movie_folder_name()` relies on a `<Part>` element that only exists at the episode level, not the show level). For a show, there's no single file to derive it from directly.

**New in `config.py`:**
- `get_show_folder_name(rating_key)` — fetches the show's episode list via `/allLeaves`, grabs the first episode, and resolves the parent show folder from *its* `<Part>` path (going up 3 directory levels instead of 2, since a show's structure is `Show/Season NN/episode.ext`).
- `get_media_folder_name(rating_key, is_tv)` — single entry point that routes to `get_show_folder_name()` or `get_movie_folder_name()`. Movies behave identically to before (just forwards to the existing function) — no change there.

**Changes in `save.py` / `plexsend.py` / `batch.py`:**
- Replaced the `if not is_tv: get_movie_folder_name(...)` pattern with `get_media_folder_name(rating_key, is_tv)` at all 9 call sites across the three files.
- Individual season posters still always get `folder_name=None` (fall back to `{title}`) — Kometa only manages the show-level poster, never touches season posters directly, so there's no reason to resolve `{folder}` for those.

**Frontend (`OutputTab.vue`):** added `{folder}` to the TV Show section's "Available variables" list, and updated the help text (previously said "for this movie", now mentions shows too).

**Update:** 
found one more edge case while testing — shows with no season subfolder at all (episodes directly in `Show/episode.ext`, e.g. some single/mini-series) were falling through since the original folder-resolution logic assumed a fixed `Show/Season NN/episode.ext` depth. Made `extract_show_folder_name_from_episode_metadata()` detect whether the immediate parent folder looks like a season folder (`Season NN`, `Specials`) and adjust how many levels it goes up accordingly, rather than assuming a fixed depth. Verified against a show with this exact structure — resolves correctly now, and the season-subfolder case still works as before.

### Testing

- Verified with multiple real shows (mixed folder-naming conventions — with/without year, localized titles differing from the on-disk folder name) — `{folder}` correctly resolves to the real on-disk name in all cases, matching what Kometa itself uses for asset matching.
- Verified movies are completely unaffected — same behavior as before the change.
- Verified season posters still correctly fall back to `{title}`, untouched by this change.

Note: none of this does anything unless someone actually sets `{folder}` in the TV Show Save Location template (defaults to `{title}` still) — so this is purely additive, nothing changes for existing setups unless opted into.

All files updated on my fork if you want to take a look.
